### PR TITLE
Fix memory leak

### DIFF
--- a/v1/backends/amqp.go
+++ b/v1/backends/amqp.go
@@ -34,7 +34,10 @@ type AMQPBackend struct {
 
 // NewAMQPBackend creates AMQPBackend instance
 func NewAMQPBackend(cnf *config.Config) Interface {
-	return &AMQPBackend{cnf: cnf, AMQPConnector: common.NewAMQPConnector()}
+	return &AMQPBackend{
+		cnf:           cnf,
+		AMQPConnector: common.NewAMQPConnector(cnf.Broker, cnf.TLSConfig),
+	}
 }
 
 // InitGroup creates and saves a group meta data object
@@ -46,7 +49,7 @@ func (b *AMQPBackend) InitGroup(groupUUID string, taskUUIDs []string) error {
 // NOTE: Given AMQP limitation this will only return true if all finished
 // tasks were successful as we do not keep track of completed failed tasks
 func (b *AMQPBackend) GroupCompleted(groupUUID string, groupTaskCount int) (bool, error) {
-	conn, channel, err := b.Open(b.cnf.Broker, b.cnf.TLSConfig)
+	conn, channel, err := b.GetConn()
 	if err != nil {
 		return false, err
 	}
@@ -62,7 +65,7 @@ func (b *AMQPBackend) GroupCompleted(groupUUID string, groupTaskCount int) (bool
 
 // GroupTaskStates returns states of all tasks in the group
 func (b *AMQPBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
-	conn, channel, err := b.Open(b.cnf.Broker, b.cnf.TLSConfig)
+	conn, channel, err := b.GetConn()
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +117,7 @@ func (b *AMQPBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*
 // whether the worker should trigger chord (true) or no if it has been triggered
 // already (false)
 func (b *AMQPBackend) TriggerChord(groupUUID string) (bool, error) {
-	conn, channel, err := b.Open(b.cnf.Broker, b.cnf.TLSConfig)
+	conn, channel, err := b.GetConn()
 	if err != nil {
 		return false, err
 	}
@@ -192,9 +195,7 @@ func (b *AMQPBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 		// Time after that the queue will be deleted.
 		"x-expires": int32(b.getExpiresIn()),
 	}
-	conn, channel, _, _, _, err := b.Connect(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, _, _, _, err := b.Connect(
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
 		taskUUID,                // queue name
@@ -208,7 +209,7 @@ func (b *AMQPBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer b.Close(channel, conn)
+	defer channel.Close()
 
 	d, ok, err := channel.Get(
 		taskUUID, // queue name
@@ -234,7 +235,7 @@ func (b *AMQPBackend) GetState(taskUUID string) (*tasks.TaskState, error) {
 
 // PurgeState deletes stored task state
 func (b *AMQPBackend) PurgeState(taskUUID string) error {
-	conn, channel, err := b.Open(b.cnf.Broker, b.cnf.TLSConfig)
+	conn, channel, err := b.GetConn()
 	if err != nil {
 		return err
 	}
@@ -245,7 +246,7 @@ func (b *AMQPBackend) PurgeState(taskUUID string) error {
 
 // PurgeGroupMeta deletes stored group meta data
 func (b *AMQPBackend) PurgeGroupMeta(groupUUID string) error {
-	conn, channel, err := b.Open(b.cnf.Broker, b.cnf.TLSConfig)
+	conn, channel, err := b.GetConn()
 	if err != nil {
 		return err
 	}
@@ -270,9 +271,7 @@ func (b *AMQPBackend) updateState(taskState *tasks.TaskState) error {
 		// Time after that the queue will be deleted.
 		"x-expires": int32(b.getExpiresIn()),
 	}
-	conn, channel, queue, confirmsChan, _, err := b.Connect(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, queue, confirmsChan, _, err := b.Connect(
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
 		taskState.TaskUUID,      // queue name
@@ -286,7 +285,7 @@ func (b *AMQPBackend) updateState(taskState *tasks.TaskState) error {
 	if err != nil {
 		return err
 	}
-	defer b.Close(channel, conn)
+	defer channel.Close()
 
 	if err := channel.Publish(
 		b.cnf.AMQP.Exchange, // exchange
@@ -341,9 +340,7 @@ func (b *AMQPBackend) markTaskCompleted(signature *tasks.Signature, taskState *t
 		// Time after that the queue will be deleted.
 		"x-expires": int32(b.getExpiresIn()),
 	}
-	conn, channel, queue, confirmsChan, _, err := b.Connect(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, queue, confirmsChan, _, err := b.Connect(
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
 		signature.GroupUUID,     // queue name
@@ -357,7 +354,7 @@ func (b *AMQPBackend) markTaskCompleted(signature *tasks.Signature, taskState *t
 	if err != nil {
 		return err
 	}
-	defer b.Close(channel, conn)
+	defer channel.Close()
 
 	if err := channel.Publish(
 		b.cnf.AMQP.Exchange, // exchange

--- a/v1/brokers/amqp.go
+++ b/v1/brokers/amqp.go
@@ -22,16 +22,17 @@ type AMQPBroker struct {
 
 // NewAMQPBroker creates new AMQPBroker instance
 func NewAMQPBroker(cnf *config.Config) Interface {
-	return &AMQPBroker{Broker: New(cnf), AMQPConnector: common.NewAMQPConnector()}
+	return &AMQPBroker{
+		Broker:        New(cnf),
+		AMQPConnector: common.NewAMQPConnector(cnf.Broker, cnf.TLSConfig),
+	}
 }
 
 // StartConsuming enters a loop and waits for incoming messages
 func (b *AMQPBroker) StartConsuming(consumerTag string, concurrency int, taskProcessor TaskProcessor) (bool, error) {
 	b.startConsuming(consumerTag, taskProcessor)
 
-	conn, channel, queue, _, amqpCloseChan, err := b.Connect(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, queue, _, amqpCloseChan, err := b.Connect(
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
 		b.cnf.DefaultQueue,      // queue name
@@ -46,7 +47,7 @@ func (b *AMQPBroker) StartConsuming(consumerTag string, concurrency int, taskPro
 		b.retryFunc(b.retryStopChan)
 		return b.retry, err
 	}
-	defer b.Close(channel, conn)
+	defer channel.Close()
 
 	if err = channel.Qos(
 		b.cnf.AMQP.PrefetchCount,
@@ -104,9 +105,7 @@ func (b *AMQPBroker) Publish(signature *tasks.Signature) error {
 		return fmt.Errorf("JSON marshal error: %s", err)
 	}
 
-	_, channel, _, confirmsChan, _, err := b.ConnectKeepAlive(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, _, confirmsChan, _, err := b.Connect(
 		b.cnf.AMQP.Exchange,     // exchange name
 		b.cnf.AMQP.ExchangeType, // exchange type
 		b.cnf.DefaultQueue,      // queue name
@@ -262,9 +261,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 		// Time after that the queue will be deleted.
 		"x-expires": delayMs * 2,
 	}
-	conn, channel, _, _, _, err := b.Connect(
-		b.cnf.Broker,
-		b.cnf.TLSConfig,
+	channel, _, _, _, err := b.Connect(
 		b.cnf.AMQP.Exchange,                     // exchange name
 		b.cnf.AMQP.ExchangeType,                 // exchange type
 		queueName,                               // queue name
@@ -278,7 +275,7 @@ func (b *AMQPBroker) delay(signature *tasks.Signature, delayMs int64) error {
 	if err != nil {
 		return err
 	}
-	defer b.Close(channel, conn)
+	defer channel.Close()
 
 	if err := channel.Publish(
 		b.cnf.AMQP.Exchange, // exchange

--- a/v1/common/amqp.go
+++ b/v1/common/amqp.go
@@ -10,37 +10,27 @@ import (
 
 // AMQPConnector ...
 type AMQPConnector struct {
-	conn     *amqp.Connection
-	connChan chan *amqp.Error
-	mu       *sync.Mutex
+	connManager *amqpConnManager
 }
 
-func NewAMQPConnector() *AMQPConnector {
+func NewAMQPConnector(url string, tlsConfig *tls.Config) *AMQPConnector {
 	return &AMQPConnector{
-		mu: &sync.Mutex{},
+		connManager: newAMQPConnManager(url, tlsConfig),
 	}
 }
 
 // Connect opens a connection to RabbitMQ, declares an exchange, opens a channel,
 // declares and binds the queue and enables publish notifications
-func (ac *AMQPConnector) Connect(url string, tlsConfig *tls.Config, exchange, exchangeType, queueName string, queueDurable, queueDelete bool, queueBindingKey string, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs amqp.Table) (*amqp.Connection, *amqp.Channel, amqp.Queue, <-chan amqp.Confirmation, <-chan *amqp.Error, error) {
-	return ac.connect(false, url, tlsConfig, exchange, exchangeType, queueName, queueDurable, queueDelete, queueBindingKey, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs)
-}
-
-func (ac *AMQPConnector) ConnectKeepAlive(url string, tlsConfig *tls.Config, exchange, exchangeType, queueName string, queueDurable, queueDelete bool, queueBindingKey string, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs amqp.Table) (*amqp.Connection, *amqp.Channel, amqp.Queue, <-chan amqp.Confirmation, <-chan *amqp.Error, error) {
-	return ac.connect(true, url, tlsConfig, exchange, exchangeType, queueName, queueDurable, queueDelete, queueBindingKey, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs)
-}
-
-func (ac *AMQPConnector) connect(keepAlive bool, url string, tlsConfig *tls.Config, exchange, exchangeType, queueName string, queueDurable, queueDelete bool, queueBindingKey string, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs amqp.Table) (*amqp.Connection, *amqp.Channel, amqp.Queue, <-chan amqp.Confirmation, <-chan *amqp.Error, error) {
+func (ac *AMQPConnector) Connect(exchange, exchangeType, queueName string, queueDurable, queueDelete bool, queueBindingKey string, exchangeDeclareArgs, queueDeclareArgs, queueBindingArgs amqp.Table) (*amqp.Channel, amqp.Queue, <-chan amqp.Confirmation, <-chan *amqp.Error, error) {
 	// Connect to server
-	conn, channel, err := ac.open(url, tlsConfig, keepAlive)
+	conn, channel, err := ac.GetConn()
 	if err != nil {
-		return nil, nil, amqp.Queue{}, nil, nil, err
+		return nil, amqp.Queue{}, nil, nil, err
 	}
 
 	if exchange != "" {
 		// Declare an exchange
-		if err = channel.ExchangeDeclare(
+		err := channel.ExchangeDeclare(
 			exchange,            // name of the exchange
 			exchangeType,        // type
 			true,                // durable
@@ -48,8 +38,10 @@ func (ac *AMQPConnector) connect(keepAlive bool, url string, tlsConfig *tls.Conf
 			false,               // internal
 			false,               // noWait
 			exchangeDeclareArgs, // arguments
-		); err != nil {
-			return conn, channel, amqp.Queue{}, nil, nil, fmt.Errorf("Exchange declare error: %s", err)
+		)
+		if err != nil {
+			channel.Close()
+			return nil, amqp.Queue{}, nil, nil, fmt.Errorf("Exchange declare error: %s", err)
 		}
 	}
 
@@ -65,27 +57,31 @@ func (ac *AMQPConnector) connect(keepAlive bool, url string, tlsConfig *tls.Conf
 			queueDeclareArgs, // arguments
 		)
 		if err != nil {
-			return conn, channel, amqp.Queue{}, nil, nil, fmt.Errorf("Queue declare error: %s", err)
+			channel.Close()
+			return nil, amqp.Queue{}, nil, nil, fmt.Errorf("Queue declare error: %s", err)
 		}
 
 		// Bind the queue
-		if err = channel.QueueBind(
+		err = channel.QueueBind(
 			queue.Name,       // name of the queue
 			queueBindingKey,  // binding key
 			exchange,         // source exchange
 			false,            // noWait
 			queueBindingArgs, // arguments
-		); err != nil {
-			return conn, channel, queue, nil, nil, fmt.Errorf("Queue bind error: %s", err)
+		)
+		if err != nil {
+			channel.Close()
+			return nil, amqp.Queue{}, nil, nil, fmt.Errorf("Queue bind error: %s", err)
 		}
 	}
 
 	// Enable publish confirmations
-	if err = channel.Confirm(false); err != nil {
-		return conn, channel, queue, nil, nil, fmt.Errorf("Channel could not be put into confirm mode: %s", err)
+	if err := channel.Confirm(false); err != nil {
+		channel.Close()
+		return nil, amqp.Queue{}, nil, nil, fmt.Errorf("Channel could not be put into confirm mode: %s", err)
 	}
 
-	return conn, channel, queue, channel.NotifyPublish(make(chan amqp.Confirmation, 1)), conn.NotifyClose(make(chan *amqp.Error, 1)), nil
+	return channel, queue, channel.NotifyPublish(make(chan amqp.Confirmation, 1)), conn.NotifyClose(make(chan *amqp.Error, 1)), nil
 }
 
 // DeleteQueue deletes a queue by name
@@ -107,81 +103,13 @@ func (*AMQPConnector) InspectQueue(channel *amqp.Channel, queueName string) (*am
 	if err != nil {
 		return nil, fmt.Errorf("Queue inspect error: %s", err)
 	}
-
 	return &queueState, nil
 }
 
-// Open new RabbitMQ connection
-func (ac *AMQPConnector) Open(url string, tlsConfig *tls.Config) (*amqp.Connection, *amqp.Channel, error) {
-	return ac.open(url, tlsConfig, false)
+func (ac *AMQPConnector) GetConn() (*amqp.Connection, *amqp.Channel, error) {
+	return ac.connManager.getConn()
 }
 
-func (ac *AMQPConnector) open(url string, tlsConfig *tls.Config, keepAlive bool) (*amqp.Connection, *amqp.Channel, error) {
-	conn, err := ac.getConn(url, tlsConfig, keepAlive)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	channel, err := conn.Channel()
-	if err != nil {
-		return nil, nil, fmt.Errorf("Open channel error: %s", err)
-	}
-
-	return conn, channel, nil
-}
-
-func (ac *AMQPConnector) getConn(url string, tlsConfig *tls.Config, keepAlive bool) (*amqp.Connection, error) {
-	ac.mu.Lock()
-	defer ac.mu.Unlock()
-
-	if !keepAlive {
-		return ac.createNewConn(url, tlsConfig)
-	}
-
-	if ac.conn == nil {
-		return ac.createAndStoreNewConn(url, tlsConfig)
-	}
-
-	select {
-	case <-ac.connChan:
-		return ac.createAndStoreNewConn(url, tlsConfig)
-	default:
-		return ac.conn, nil
-	}
-}
-
-func (ac *AMQPConnector) createNewConn(url string, tlsConfig *tls.Config) (*amqp.Connection, error) {
-	// From amqp docs: DialTLS will use the provided tls.Config when it encounters an amqps:// scheme
-	// and will dial a plain connection when it encounters an amqp:// scheme.
-	conn, err := amqp.DialTLS(url, tlsConfig)
-	if err != nil {
-		return nil, fmt.Errorf("Dial error: %s", err)
-	}
-	return conn, nil
-}
-
-func (ac *AMQPConnector) createAndStoreNewConn(url string, tlsConfig *tls.Config) (*amqp.Connection, error) {
-	conn, err := ac.createNewConn(url, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-	ac.setConn(conn)
-	return conn, nil
-}
-
-func (ac *AMQPConnector) setConn(conn *amqp.Connection) {
-	if ac.conn != nil {
-		// This should fix the memory leak: even if the connection is dead, apparently
-		// it's needed to explicitly close the connection because of how it's implemented.
-		ac.conn.Close()
-	}
-
-	ac.conn = conn
-	ac.connChan = make(chan *amqp.Error)
-	conn.NotifyClose(ac.connChan)
-}
-
-// Close connection
 func (ac *AMQPConnector) Close(channel *amqp.Channel, conn *amqp.Connection) error {
 	if channel != nil {
 		if err := channel.Close(); err != nil {
@@ -195,5 +123,59 @@ func (ac *AMQPConnector) Close(channel *amqp.Channel, conn *amqp.Connection) err
 		}
 	}
 
+	return nil
+}
+
+type amqpConnManager struct {
+	url       string
+	tlsConfig *tls.Config
+	conn      *amqp.Connection
+	connID    int
+	closeChan chan *amqp.Error
+	mu        *sync.Mutex
+}
+
+func newAMQPConnManager(url string, tlsConfig *tls.Config) *amqpConnManager {
+	closeChan := make(chan *amqp.Error, 1)
+	closeChan <- amqp.ErrClosed // get ready for the first getConn
+	return &amqpConnManager{
+		url:       url,
+		tlsConfig: tlsConfig,
+		closeChan: closeChan,
+		mu:        &sync.Mutex{},
+	}
+}
+
+func (m *amqpConnManager) getConn() (*amqp.Connection, *amqp.Channel, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	select {
+	case <-m.closeChan:
+		err := m.makeConn()
+		if err != nil {
+			return nil, nil, err
+		}
+	default:
+	}
+
+	channel, err := m.conn.Channel()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Open channel error: %s", err)
+	}
+
+	return m.conn, channel, nil
+}
+
+func (m *amqpConnManager) makeConn() error {
+	if m.conn != nil {
+		m.conn.Close() // this is most likely useless, but just to be sure
+	}
+	conn, err := amqp.DialTLS(m.url, m.tlsConfig)
+	if err != nil {
+		return err
+	}
+	m.closeChan = conn.NotifyClose(make(chan *amqp.Error, 1))
+	m.conn = conn
 	return nil
 }

--- a/v1/common/amqp.go
+++ b/v1/common/amqp.go
@@ -170,6 +170,12 @@ func (ac *AMQPConnector) createAndStoreNewConn(url string, tlsConfig *tls.Config
 }
 
 func (ac *AMQPConnector) setConn(conn *amqp.Connection) {
+	if ac.conn != nil {
+		// This should fix the memory leak: even if the connection is dead, apparently
+		// it's needed to explicitly close the connection because of how it's implemented.
+		ac.conn.Close()
+	}
+
 	ac.conn = conn
 	ac.connChan = make(chan *amqp.Error)
 	conn.NotifyClose(ac.connChan)

--- a/v1/factories_test.go
+++ b/v1/factories_test.go
@@ -89,11 +89,7 @@ func TestBackendFactory(t *testing.T) {
 	actual, err := machinery.BackendFactory(&cnf)
 	if assert.NoError(t, err) {
 		expected := backends.NewAMQPBackend(&cnf)
-		assert.True(
-			t,
-			reflect.DeepEqual(actual, expected),
-			fmt.Sprintf("conn = %v, want %v", actual, expected),
-		)
+		assert.IsType(t, expected, actual)
 	}
 
 	// 2) Memcache backend test


### PR DESCRIPTION
The latest changes apparently introduced a mid-term memory leak.

The leak is caused by spamming `NotifyClose` calls on the shared connection, which causes the internal AMQP queue of listeners to grow indefinitely. There are also other smaller potential leakages which are fixed by this PR as well.

In order to make sense of the changes, the code is adjusted accordingly, since the connection itself is not exposed anymore in any way, but rather only AMQP Channels are exposed.

1) Do not spam `NotifyClose` calls on the connection when publishing.
2) Treat all connections from either AMQP brokers and servers the same, reusing previous connections and replacing them when closed. This is managed by a single component in the `AMQPConnector` struct, `amqpConnManager`. This way the entry point for connections is unified and there are no logical branches between different `Connect` calls.
3) Be sure to explicitly close all channels when failing during connections (e.g.: old `v1/common/amqp.go`, line `51`): if a connection is spawned and one of the channel commands fails the channel is not explicitly closed (in the caller's code the error is returned immediately without reaching the deferred close operation) while the connection remains active and with an active ref to the channel itself.
4) Rename functions to make sense: `Connect` is now `Exchange` and returns a channel, a queue, and the ack channel. It does not return a close channel anymore because failures can be obtained directly from the `ErrChan` function of the broker. `Open` is now `Channel` since it just returns the newly created channel.