### PR TITLE
Retry to establish a connection directly in the makeConnection method

### DIFF
--- a/v1/common/amqp.go
+++ b/v1/common/amqp.go
@@ -35,6 +35,7 @@ func (ac *AMQPConnector) Exchange(exchange, exchangeType, queueName string, queu
 			lastErr = err
 			_, connErr := err.(amqpConnError)
 			if connErr || err == amqp.ErrClosed {
+				time.Sleep(ac.exchangeRetryTimeout)
 				continue
 			}
 			return nil, amqp.Queue{}, nil, err

--- a/v1/common/amqp.go
+++ b/v1/common/amqp.go
@@ -17,13 +17,43 @@ type AMQPConnector struct {
 	exchangeRetryTimeout time.Duration
 }
 
-func NewAMQPConnector(url string, tlsConfig *tls.Config) *AMQPConnector {
-	return &AMQPConnector{
+type AMQPConnectorOption func(c *AMQPConnector)
+
+func WithAMQPExchangeMaxRetries(retries int) AMQPConnectorOption {
+	return func(c *AMQPConnector) {
+		c.exchangeMaxRetries = retries
+	}
+}
+
+func WithAMQPExchangeRetryTimeout(timeout time.Duration) AMQPConnectorOption {
+	return func(c *AMQPConnector) {
+		c.exchangeRetryTimeout = timeout
+	}
+}
+
+func WithAMQPConnectionMaxRetries(retries int) AMQPConnectorOption {
+	return func(c *AMQPConnector) {
+		c.connManager.connectionMaxRetries = retries
+	}
+}
+
+func WithAMQPConnectionRetryTimeout(timeout time.Duration) AMQPConnectorOption {
+	return func(c *AMQPConnector) {
+		c.connManager.connectionRetryTimeout = timeout
+	}
+}
+
+func NewAMQPConnector(url string, tlsConfig *tls.Config, opts ...AMQPConnectorOption) *AMQPConnector {
+	c := &AMQPConnector{
 		connManager: newAMQPConnectionManager(url, tlsConfig),
 
 		exchangeMaxRetries:   3,
 		exchangeRetryTimeout: time.Second,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 type wrappedError struct {

--- a/v1/common/amqp.go
+++ b/v1/common/amqp.go
@@ -224,7 +224,7 @@ func (m *amqpConnectionManager) makeConnection() (*amqp.Connection, error) {
 		conn, err := amqp.DialTLS(m.url, m.tlsConfig)
 		if err != nil {
 			if retries >= m.connectionMaxRetries {
-				return nil, err
+				return nil, wrapError("too many retries", err)
 			}
 			time.Sleep(m.connectionRetryTimeout)
 			continue // TODO log warning here?

--- a/v1/common/amqp_test.go
+++ b/v1/common/amqp_test.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeouts(t *testing.T) {
+	c := NewAMQPConnector("", nil)
+	assert.Equal(t, c.exchangeMaxRetries, 3)
+	assert.Equal(t, c.exchangeRetryTimeout, time.Second)
+	assert.Equal(t, c.connManager.connectionMaxRetries, 3)
+	assert.Equal(t, c.connManager.connectionRetryTimeout, 5*time.Second)
+	c = NewAMQPConnector("", nil,
+		WithAMQPConnectionMaxRetries(10),
+		WithAMQPConnectionRetryTimeout(time.Minute),
+		WithAMQPExchangeMaxRetries(20),
+		WithAMQPExchangeRetryTimeout(time.Hour),
+	)
+	assert.Equal(t, c.exchangeMaxRetries, 20)
+	assert.Equal(t, c.exchangeRetryTimeout, time.Hour)
+	assert.Equal(t, c.connManager.connectionMaxRetries, 10)
+	assert.Equal(t, c.connManager.connectionRetryTimeout, time.Minute)
+}


### PR DESCRIPTION
Instead of waiting for next invocation, immediately retry to establish failed AMQP connections in the connection manager's `makeConnection` method, and give up after some failed retries.