### PR TITLE
[API-98] fix/change-quit-message-log-level

### DIFF
--- a/v1/worker.go
+++ b/v1/worker.go
@@ -59,7 +59,7 @@ func (worker *Worker) Launch() error {
 
 	go func() {
 		err := fmt.Errorf("Signal received: %v. Quitting the worker", <-sig)
-		log.WARNING.Print(err.Error())
+		log.INFO.Print(err.Error())
 		worker.Quit()
 		errorsChan <- err
 	}()


### PR DESCRIPTION
Change log level to not trigger sentry records when quiting