### PR TITLE
Simplify error checks

### DIFF
--- a/backends/memcache.go
+++ b/backends/memcache.go
@@ -71,7 +71,7 @@ func (b *MemcacheBackend) GroupCompleted(groupUUID string, groupTaskCount int) (
 func (b *MemcacheBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
 	groupMeta, err := b.getGroupMeta(groupUUID)
 	if err != nil {
-		return []*tasks.TaskState{}, err
+		return nil, err
 	}
 
 	return b.getStates(groupMeta.TaskUUIDs...)

--- a/backends/mongodb.go
+++ b/backends/mongodb.go
@@ -63,7 +63,7 @@ func (b *MongodbBackend) GroupCompleted(groupUUID string, groupTaskCount int) (b
 func (b *MongodbBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
 	groupMeta, err := b.getGroupMeta(groupUUID)
 	if err != nil {
-		return []*tasks.TaskState{}, err
+		return nil, err
 	}
 
 	return b.getStates(groupMeta.TaskUUIDs...)
@@ -247,10 +247,7 @@ func (b *MongodbBackend) updateState(signature *tasks.Signature, update bson.M) 
 
 	update = bson.M{"$set": update}
 	_, err := b.tasksCollection.UpsertId(signature.UUID, update)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // connect returns a session if we are already connected to mongo, otherwise

--- a/backends/redis.go
+++ b/backends/redis.go
@@ -87,7 +87,7 @@ func (b *RedisBackend) GroupCompleted(groupUUID string, groupTaskCount int) (boo
 func (b *RedisBackend) GroupTaskStates(groupUUID string, groupTaskCount int) ([]*tasks.TaskState, error) {
 	groupMeta, err := b.getGroupMeta(groupUUID)
 	if err != nil {
-		return []*tasks.TaskState{}, err
+		return nil, err
 	}
 
 	return b.getStates(groupMeta.TaskUUIDs...)
@@ -127,11 +127,7 @@ func (b *RedisBackend) TriggerChord(groupUUID string) (bool, error) {
 	}
 
 	_, err = conn.Do("SET", groupUUID, encoded)
-	if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return err == nil, err
 }
 
 // SetStatePending updates task state to PENDING
@@ -194,11 +190,7 @@ func (b *RedisBackend) PurgeState(taskUUID string) error {
 	defer conn.Close()
 
 	_, err := conn.Do("DEL", taskUUID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // PurgeGroupMeta deletes stored group meta data
@@ -207,11 +199,7 @@ func (b *RedisBackend) PurgeGroupMeta(groupUUID string) error {
 	defer conn.Close()
 
 	_, err := conn.Do("DEL", groupUUID)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // getGroupMeta retrieves group meta data, convenience function to avoid repetition
@@ -299,11 +287,7 @@ func (b *RedisBackend) setExpirationTime(key string) error {
 	defer conn.Close()
 
 	_, err := conn.Do("EXPIREAT", key, expirationTimestamp)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // open returns or creates instance of Redis connection

--- a/common/redis.go
+++ b/common/redis.go
@@ -27,7 +27,7 @@ func (rc *RedisConnector) NewPool(socketPath, host, password string, db int) *re
 			if err != nil {
 				return nil, err
 			}
-			return c, err
+			return c, nil
 		},
 		// PINGs connections that have been idle more than 10 seconds
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {


### PR DESCRIPTION
* also use nil as default for slices in backend group state getters.