### PR TITLE
Drop duplicated validation in register

### DIFF
--- a/server.go
+++ b/server.go
@@ -92,9 +92,6 @@ func (server *Server) SetConfig(cnf *config.Config) {
 // RegisterTasks registers all tasks at once
 func (server *Server) RegisterTasks(namedTaskFuncs map[string]interface{}) error {
 	for name, task := range namedTaskFuncs {
-		if err := tasks.ValidateTask(task); err != nil {
-			return err
-		}
 		if err := server.RegisterTask(name, task); err != nil {
 			return err
 		}


### PR DESCRIPTION
`RegisterTasks` validates the tasks then calls `RegisterTask` which already does the validation so drop the validation in multiple register to reuse one register validation.