### PR TITLE
Put connector as first field for better memory alignment

### DIFF
--- a/backends/redis.go
+++ b/backends/redis.go
@@ -16,6 +16,7 @@ import (
 
 // RedisBackend represents a Memcache result backend
 type RedisBackend struct {
+	common.RedisConnector
 	cnf      *config.Config
 	host     string
 	password string
@@ -24,7 +25,6 @@ type RedisBackend struct {
 	// If set, path to a socket file overrides hostname
 	socketPath string
 	redsync    *redsync.Redsync
-	common.RedisConnector
 }
 
 // NewRedisBackend creates RedisBackend instance

--- a/brokers/redis.go
+++ b/brokers/redis.go
@@ -19,6 +19,7 @@ var redisDelayedTasksKey = "delayed_tasks"
 
 // RedisBroker represents a Redis broker
 type RedisBroker struct {
+	common.RedisConnector
 	host              string
 	password          string
 	db                int
@@ -31,7 +32,6 @@ type RedisBroker struct {
 	socketPath string
 	redsync    *redsync.Redsync
 	Broker
-	common.RedisConnector
 }
 
 // NewRedisBroker creates new RedisBroker instance


### PR DESCRIPTION
Having empty struct as the first field, aligns memory better.