### PR TITLE
Make workaround for go coverpkg bug

### DIFF
--- a/integration-tests/stub.go
+++ b/integration-tests/stub.go
@@ -1,0 +1,5 @@
+package integration
+
+// This file is here to workaround a go bug
+// -coverpkg=all fails a package contains only test files
+// https://github.com/golang/go/issues/27333


### PR DESCRIPTION
Add a stub file for https://github.com/golang/go/issues/27333